### PR TITLE
Multiple files

### DIFF
--- a/src/crixus.cpp
+++ b/src/crixus.cpp
@@ -258,11 +258,12 @@ int vtk_output (OutBuf *buf, int len, const char *filename){
   return 0;
 }
 
+// Wrapper for {hdf5,vtk}_output()
 int generic_output(OutBuf *buf, int start, int nelem, const char* outname_c, int opt)
 {
   string outname(outname_c);
-  // something's really wrong if opt is not 1 nor 2
-  int err = INTERNAL_ERROR;
+  int err = 0;
+
   if(opt==2){
     outname = "0." + outname + ".h5sph";
     cout << "Writing output to file " << outname << " ...";
@@ -275,6 +276,9 @@ int generic_output(OutBuf *buf, int start, int nelem, const char* outname_c, int
     fflush(stdout);
     err = vtk_output( buf + start, nelem, outname.c_str());
   }
+  else
+    // something's really wrong if opt is not 1 nor 2
+    return err = INTERNAL_ERROR;
 
   if(err==0){ cout << " [OK]" << endl; }
   else {

--- a/src/crixus.cpp
+++ b/src/crixus.cpp
@@ -258,6 +258,32 @@ int vtk_output (OutBuf *buf, int len, const char *filename){
   return 0;
 }
 
+int generic_output(OutBuf *buf, int start, int nelem, const char* outname_c, int opt)
+{
+  string outname(outname_c);
+  // something's really wrong if opt is not 1 nor 2
+  int err = INTERNAL_ERROR;
+  if(opt==2){
+    outname = "0." + outname + ".h5sph";
+    cout << "Writing output to file " << outname << " ...";
+    fflush(stdout);
+    err = hdf5_output( buf + start, nelem, outname.c_str());
+  }
+  else if(opt==1){
+    outname += ".vtu";
+    cout << "Writing output to file " << outname << " ...";
+    fflush(stdout);
+    err = vtk_output( buf + start, nelem, outname.c_str());
+  }
+
+  if(err==0){ cout << " [OK]" << endl; }
+  else {
+    cout << " [FAILED]" << endl;
+    err = WRITE_FAIL;
+  }
+  return err;
+}
+
 /* auxiliary functions to write data array entrypoints */
 inline void
 scalar_array(FILE *fid, const char *type, const char *name, size_t offset)

--- a/src/crixus.cu
+++ b/src/crixus.cu
@@ -1153,6 +1153,8 @@ int crixus_main(int argc, char** argv){
   cout << " [OK]" << endl;
 
   cout << "Sorting particles according to special boundary id...";
+  fflush(stdout);
+
   // allocate per-Kent arrays
   OutBuf **perKentBufs = new OutBuf*[num_kents]; // particle[kent][part_idx]
   int *perKentCopiedParts = new int[num_kents]; // #copied_particles[kent]

--- a/src/crixus.cu
+++ b/src/crixus.cu
@@ -1157,14 +1157,25 @@ int crixus_main(int argc, char** argv){
   OutBuf **perKentBufs = new OutBuf*[num_kents]; // particle[kent][part_idx]
   int *perKentCopiedParts = new int[num_kents]; // #copied_particles[kent]
   for (int k = 0; k < num_kents; k++) {
-    perKentBufs[k] = new OutBuf[ num_parts_per_kent[k] ];
+    if (num_parts_per_kent[k] > 0)
+      perKentBufs[k] = new OutBuf[ num_parts_per_kent[k] ];
+    else
+      perKentBufs[k] = NULL;
     perKentCopiedParts[k] = 0;
   }
   // copy particles
   for (int i = 0; i < nelem; i++) {
     const int curr_particle_kent = buf[i].kent;
-    perKentBufs[ curr_particle_kent ][ perKentCopiedParts[curr_particle_kent] ] = buf[i];
-    perKentCopiedParts[ curr_particle_kent ] ++;
+    // ensure there is at least one particle with given kent
+    if (num_parts_per_kent[curr_particle_kent] > 0) {
+        if (perKentCopiedParts[curr_particle_kent] >= num_parts_per_kent[curr_particle_kent]) {
+          cout << "Internal error: counted " << num_parts_per_kent[curr_particle_kent] << " particles with kent " <<
+            curr_particle_kent << ", found more. Aborting..." << endl;
+          return INTERNAL_ERROR;
+        }
+        perKentBufs[ curr_particle_kent ][ perKentCopiedParts[curr_particle_kent] ] = buf[i];
+        perKentCopiedParts[ curr_particle_kent ] ++;
+    }
    }
   cout << " [OK]" << endl;
 

--- a/src/crixus.cu
+++ b/src/crixus.cu
@@ -988,6 +988,9 @@ int crixus_main(int argc, char** argv){
   cout << "Creating and initializing of output buffer of particles ...";
   fflush(stdout);
   OutBuf *buf, *beBuf;
+
+  int num_fluid_particles = 0;
+  int num_boundary_particles = 0;
 #ifndef bdebug
   unsigned int nelem = nvert+nbe+nfluid;
 #else
@@ -1029,6 +1032,7 @@ int crixus_main(int argc, char** argv){
       buf[k].ep2 = 0;
       buf[k].ep3 = 0;
       k++;
+      num_fluid_particles++;
     }
   }
   //vertex particles
@@ -1064,6 +1068,7 @@ int crixus_main(int argc, char** argv){
     buf[k].ep2 = 0;
     buf[k].ep3 = 0;
     k++;
+    num_boundary_particles++;
   }
   const unsigned int nCur = k;
   //boundary segments
@@ -1097,6 +1102,7 @@ int crixus_main(int argc, char** argv){
     beBuf[k-nCur].ep2 = nfluid+ep[i-nvert].a[1] - nvshift[ep[i-nvert].a[1]];
     beBuf[k-nCur].ep3 = nfluid+ep[i-nvert].a[2] - nvshift[ep[i-nvert].a[2]];
     k++;
+    num_boundary_particles++;
   }
   // isbe contains the current index of each sbi
   isbe[0] = 0;
@@ -1145,10 +1151,12 @@ int crixus_main(int argc, char** argv){
   string outname = configfname.substr(0,configfname.length()-4);
   outname = config.Get("output", "name", outname);
 
-  err = generic_output(buf, 0, nelem, outname.c_str(), opt);
-
-  if (err != 0)
-    return err;
+  string curr_outname = outname + ".fluid";
+  err = generic_output(buf, 0, num_fluid_particles, curr_outname.c_str(), opt);
+  if (err != 0) return err;
+  curr_outname = outname + ".boundary";
+  err = generic_output(buf, num_fluid_particles, num_boundary_particles, curr_outname.c_str(), opt);
+  if (err != 0) return err;
 
   //Free memory
   //Arrays

--- a/src/crixus.cu
+++ b/src/crixus.cu
@@ -1180,16 +1180,16 @@ int crixus_main(int argc, char** argv){
       if (k == 0)
         allocate_for_curr_kent -= num_fluid_particles;
       // do not allocate if there are 0 parts with current kent (unlikely)
-      if (num_parts_per_kent[k] > 0)
-        perKentBufs[k] = new OutBuf[ num_parts_per_kent[k] ];
+      if (allocate_for_curr_kent > 0)
+        perKentBufs[k] = new OutBuf[ allocate_for_curr_kent ];
       else
         perKentBufs[k] = NULL;
       // initialize progressive index
       perKentCopiedParts[k] = 0;
     }
 
-    // copy particles
-    for (int i = 0; i < nelem; i++) {
+    // copy particles, excluding fluid ones
+    for (int i = num_fluid_particles; i < nelem; i++) {
       const int curr_particle_kent = buf[i].kent;
       // ensure there is at least one particle with given kent
       if (num_parts_per_kent[curr_particle_kent] > 0) {

--- a/src/crixus.cu
+++ b/src/crixus.cu
@@ -1005,7 +1005,7 @@ int crixus_main(int argc, char** argv){
   unsigned int nelem = nvert+nbe+nfluid+debugs;
 #endif
   buf = new OutBuf[nelem];
-  // buffer for boundary elementss
+  // buffer for boundary elements
   beBuf = new OutBuf[nbe];
   int k=0;
   unsigned int m,n,imin[3];

--- a/src/crixus.cu
+++ b/src/crixus.cu
@@ -1144,23 +1144,11 @@ int crixus_main(int argc, char** argv){
   cout << "Output format: " << outfformat << endl;
   string outname = configfname.substr(0,configfname.length()-4);
   outname = config.Get("output", "name", outname);
-  if(opt==2){
-    outname = "0." + outname + ".h5sph";
-    cout << "Writing output to file " << outname << " ...";
-    fflush(stdout);
-    err = hdf5_output( buf, nelem, outname.c_str());
-  }
-  else if(opt==1){
-    outname += ".vtu";
-    cout << "Writing output to file " << outname << " ...";
-    fflush(stdout);
-    err = vtk_output( buf, nelem, outname.c_str());
-  }
-  if(err==0){ cout << " [OK]" << endl; }
-  else {
-    cout << " [FAILED]" << endl;
-    return WRITE_FAIL;
-  }
+
+  err = generic_output(buf, 0, nelem, outname.c_str(), opt);
+
+  if (err != 0)
+    return err;
 
   //Free memory
   //Arrays

--- a/src/crixus.cu
+++ b/src/crixus.cu
@@ -1113,7 +1113,7 @@ int crixus_main(int argc, char** argv){
     beBuf[k-nCur].ep3 = nfluid+ep[i-nvert].a[2] - nvshift[ep[i-nvert].a[2]];
     k++;
     num_boundary_particles++;
-    num_parts_per_kent[ beBuf[k-nCur].kent ]++;
+    // num_parts_per_kent will be incremented while copying into buf
   }
   // isbe contains the current index of each sbi
   isbe[0] = 0;
@@ -1125,7 +1125,7 @@ int crixus_main(int argc, char** argv){
     buf[l] = beBuf[i];
     buf[l].iref = l;
     isbe[beBuf[i].kent]++;
-    // num_parts_per_kent was already incremented while filling beBuf[]
+    num_parts_per_kent[ beBuf[i].kent ]++;
   }
   delete [] nvshift;
 #ifdef bdebug

--- a/src/crixus.h
+++ b/src/crixus.h
@@ -35,6 +35,9 @@ int hdf5_output (OutBuf *buf, int len, const char *filename);
 
 int vtk_output (OutBuf *buf, int len, const char *filename);
 
+// wrapper for writer functions
+int generic_output(OutBuf *buf, int start, int nelem, const char* outname_c, int opt);
+
 inline void scalar_array(FILE *fid, const char *type, const char *name, size_t offset);
 
 inline void vector_array(FILE *fid, const char *type, const char *name, uint dim, size_t offset);

--- a/src/return.h
+++ b/src/return.h
@@ -17,5 +17,6 @@
 #define MAXLINK_TOO_SMALL -14
 #define MC_FAIL -15
 #define NO_WRITE_FILE -16
+#define INTERNAL_ERROR -17
 
 #endif


### PR DESCRIPTION
If "split" boolean option is enabled in the output section of the config files, separate files are produced for fluid and boundary particles. Boundary particles are also separated according to their KENT.

Default: do not split. Works with both HDF5 and VTK.

This feature will be used in GPUSPH the new problem interface to load different logical pieces of a problem separately.
